### PR TITLE
Gitlog improvements - Exclude current version from found git tag version list when calculate since tag version by rule

### DIFF
--- a/maven-confluence-reporting-plugin/pom.xml
+++ b/maven-confluence-reporting-plugin/pom.xml
@@ -195,7 +195,7 @@ TEST
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>4.0.0.201505050340-m2</version>
+            <version>4.0.1.201506240215-r</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.jcraft</groupId>

--- a/maven-confluence-reporting-plugin/src/main/java/com/github/qwazer/mavenplugins/gitlog/VersionUtil.java
+++ b/maven-confluence-reporting-plugin/src/main/java/com/github/qwazer/mavenplugins/gitlog/VersionUtil.java
@@ -145,6 +145,16 @@ public class VersionUtil {
         }
     }
 
+    public static Collection<String>  removeTagWithVersion(Collection<String> versionTagList, String versionTagNamePart){
+        Map<ArtifactVersion, String> map = new HashMap<ArtifactVersion, String>();
+        for (String versionTag : versionTagList) {
+            map.put(parseArtifactVersion(versionTag), versionTag);
+        }
+        ArtifactVersion currentVersion = parseArtifactVersion(versionTagNamePart);
+        map.remove(currentVersion);
+        return map.values();
+    }
+
 
     public static LinkedList<String> sortAndFilter(Collection<String> versionNameList,
                                                    String start,

--- a/maven-confluence-reporting-plugin/src/main/java/org/bsc/maven/reporting/renderer/GitLogJiraIssuesRenderer.java
+++ b/maven-confluence-reporting-plugin/src/main/java/org/bsc/maven/reporting/renderer/GitLogJiraIssuesRenderer.java
@@ -163,11 +163,12 @@ public class GitLogJiraIssuesRenderer extends AbstractMavenReportRenderer {
         return pattern;
     }
 
-    private void overrideGitLogSinceTagNameIfNeeded(Set<String> versionTagList) {
-            String tagNamePart = VersionUtil.calculateVersionTagNamePart(currentVersion, calculateRuleForSinceTagName);
-            log.info(String.format("Calculated tag name part is %s", tagNamePart));
-            String nearestVersionTagName = VersionUtil.findNearestVersionTagsBefore(versionTagList, tagNamePart);
-            gitLogSinceTagName = nearestVersionTagName;
+    protected void overrideGitLogSinceTagNameIfNeeded(Collection<String> versionTagList) {
+        String tagNamePart = VersionUtil.calculateVersionTagNamePart(currentVersion, calculateRuleForSinceTagName);
+        log.info(String.format("Calculated tag name part is %s", tagNamePart));
+        versionTagList = VersionUtil.removeTagWithVersion(versionTagList, currentVersion);
+        String nearestVersionTagName = VersionUtil.findNearestVersionTagsBefore(versionTagList, tagNamePart);
+        gitLogSinceTagName = nearestVersionTagName;
 
     }
 

--- a/maven-confluence-reporting-plugin/src/test/java/org/bsc/maven/reporting/renderer/GitLogJiraIssuesRendererTest.java
+++ b/maven-confluence-reporting-plugin/src/test/java/org/bsc/maven/reporting/renderer/GitLogJiraIssuesRendererTest.java
@@ -1,0 +1,79 @@
+package org.bsc.maven.reporting.renderer;
+
+import com.github.qwazer.mavenplugins.gitlog.CalculateRuleForSinceTagName;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugin.testing.SilentLog;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.github.qwazer.mavenplugins.gitlog.CalculateRuleForSinceTagName.*;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.*;
+
+/**
+ * @author ar
+ * @since Date: 11.07.2015
+ */
+public class GitLogJiraIssuesRendererTest {
+
+
+
+    public static GitLogJiraIssuesRenderer createRendererWithParams(String currentVersion,
+                                                                    CalculateRuleForSinceTagName rule) {
+
+        return new GitLogJiraIssuesRenderer(
+                null,
+                null,
+                null,
+                null,
+                currentVersion,
+                rule,
+                null,
+                null,
+                new SilentLog());
+
+    }
+
+
+    @Test
+    public void testOverrideGitLogSinceTagNameIfNeeded1() throws Exception {
+        GitLogJiraIssuesRenderer renderer = createRendererWithParams("12.0.0",  CURRENT_MAJOR_VERSION);
+        List<String> list = asList("10.0.0", "10.1.9", "11.0.0", "11.0.1", "11.1.10", "12.0.0");
+        renderer.overrideGitLogSinceTagNameIfNeeded(list);
+        String result = renderer.getGitLogSinceTagName();
+        assertEquals("11.1.10", result);
+    }
+
+    @Test
+    public void testOverrideGitLogSinceTagNameIfNeeded2() throws Exception {
+        GitLogJiraIssuesRenderer renderer = createRendererWithParams("12.0.0",  CURRENT_MINOR_VERSION);
+        List<String> list = asList("10.0.0", "10.1.9", "11.0.0", "11.0.1", "11.1.10", "12.0.0");
+        renderer.overrideGitLogSinceTagNameIfNeeded(list);
+        String result = renderer.getGitLogSinceTagName();
+        assertEquals("11.1.10", result);
+    }
+
+    @Test
+    public void testOverrideGitLogSinceTagNameIfNeeded3() throws Exception {
+        GitLogJiraIssuesRenderer renderer = createRendererWithParams("12.0.0",  LATEST_RELEASE_VERSION);
+        List<String> list = asList("10.0.0", "10.1.9", "11.0.0", "11.0.1", "11.1.10", "12.0.0");
+        renderer.overrideGitLogSinceTagNameIfNeeded(list);
+        String result = renderer.getGitLogSinceTagName();
+        assertEquals("11.1.10", result);
+    }
+
+    @Test
+    public void testOverrideGitLogSinceTagNameIfNeeded4() throws Exception {
+        GitLogJiraIssuesRenderer renderer = createRendererWithParams("12.0.0", LATEST_RELEASE_VERSION);
+        List<String> list = asList("10.0.0", "10.1.9", "11.0.0", "11.0.1", "11.1.10", "12.0.0", "12.1.1");
+        renderer.overrideGitLogSinceTagNameIfNeeded(list);
+        String result = renderer.getGitLogSinceTagName();
+        assertEquals("11.1.10", result);
+    }
+
+
+}


### PR DESCRIPTION
It can be useful with some cobinations of maven-release-plugin &  confluence-reporting-maven-plugin.
For example, maven release-plugin creates git tag with current version.
This tag can break CalculateRuleForSinceTagName findings

Also provide unit test class for GitLogJiraIssuesRenderer

