### PR TITLE
Fix integration tests

### DIFF
--- a/maven-confluence-itest/src/test/java/org/bsc/maven/confluence/plugin/TemplateVariablesInPagesTest.java
+++ b/maven-confluence-itest/src/test/java/org/bsc/maven/confluence/plugin/TemplateVariablesInPagesTest.java
@@ -178,7 +178,7 @@ public class TemplateVariablesInPagesTest {
     @Test
     public void shouldRenderTheIndexPage() throws IOException, VerificationException, InterruptedException {
         File testDir = simpleExtractResources(getClass(), "/simple-plugin-project");
-        testLaunchingMaven(testDir, Collections.emptyList(), "clean", "package", "confluence-reporting:deploy");
+        testLaunchingMaven(testDir, new ArrayList<>(), "clean", "package", "confluence-reporting:deploy");
         assertTrue(fileExists(testDir.getAbsolutePath() + "/results/Fake Root=>Hello Plugin"));
         assertTrue(fileExists(testDir.getAbsolutePath() + "/results/Hello Plugin=>Hello Plugin - Summary"));
 
@@ -195,7 +195,7 @@ public class TemplateVariablesInPagesTest {
     @Test
     public void shouldPutTheGoalsAsChildrenOfGoalsPage() throws IOException, VerificationException, InterruptedException {
         File testDir = simpleExtractResources(getClass(), "/plugin-project-goals-in-subpage");
-        testLaunchingMaven(testDir, Collections.emptyList(), "clean", "package", "confluence-reporting:deploy");
+        testLaunchingMaven(testDir, new ArrayList<>(), "clean", "package", "confluence-reporting:deploy");
         assertTrue(fileExists(testDir.getAbsolutePath() + "/results/Fake Root=>Hello Plugin"));
         String pluginGoalsPath = testDir.getAbsolutePath() + "/results/Hello Plugin=>Hello Plugin - Goals";
         assertTrue(fileExists(pluginGoalsPath));

--- a/maven-confluence-itest/src/test/java/org/bsc/maven/confluence/plugin/TemplateVariablesInPagesTest.java
+++ b/maven-confluence-itest/src/test/java/org/bsc/maven/confluence/plugin/TemplateVariablesInPagesTest.java
@@ -21,7 +21,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
@@ -40,6 +39,8 @@ import org.junit.Test;
 
 @SuppressWarnings("unchecked")
 public class TemplateVariablesInPagesTest {
+
+    private static final String HOME_PAGE_NAME = "Hello Plugin";
 
     public interface Handler {
         Map<String, String> getPage(String tokken, String space, String page);
@@ -77,8 +78,7 @@ public class TemplateVariablesInPagesTest {
         when(handler.logout(tokken)).thenReturn(true);
 
         when(handler.getChildren(tokken, "0")).thenReturn(new ArrayList<Map<String,String>>());
-        String homePageName = "Hello Plugin";
-        when(handler.getChildren(tokken, DigestUtils.md5Hex(homePageName))).thenReturn(new ArrayList<Map<String,String>>());
+        when(handler.getChildren(tokken, DigestUtils.md5Hex(HOME_PAGE_NAME))).thenReturn(new ArrayList<Map<String,String>>());
 
     }
 
@@ -96,11 +96,53 @@ public class TemplateVariablesInPagesTest {
         mkdir(results);
 
         final HashMap<String, Map<String,String>> titleToPage = new HashMap<>();
-        Map<String, String> homePage = new HashMap<String, String>();
+        Map<String, String> homePage = new Hashtable<>();
         homePage.put("title", "Fake Root");
         homePage.put("id", "0");
         homePage.put("space", "DOC");
         titleToPage.put("Fake Root", homePage);
+
+        Map<String, String> helloPluginPage = new Hashtable<>();
+        helloPluginPage.put("title", HOME_PAGE_NAME);
+        helloPluginPage.put("parentId", "0");
+        helloPluginPage.put("id", DigestUtils.md5Hex(HOME_PAGE_NAME));
+        helloPluginPage.put("space", "DOC");
+        titleToPage.put(HOME_PAGE_NAME, helloPluginPage);
+
+        Map<String, String> helloPluginGoalsPage = new Hashtable<>();
+        helloPluginGoalsPage.put("title", "Hello Plugin - Goals");
+        helloPluginGoalsPage.put("parentId", DigestUtils.md5Hex(HOME_PAGE_NAME));
+        helloPluginGoalsPage.put("id", DigestUtils.md5Hex("Hello Plugin - Goals"));
+        helloPluginGoalsPage.put("space", "DOC");
+        titleToPage.put("Hello Plugin - Goals", helloPluginGoalsPage);
+
+        Map<String, String> helloPluginSummaryPage = new Hashtable<>();
+        helloPluginSummaryPage.put("title", "Hello Plugin - Summary");
+        helloPluginSummaryPage.put("parentId", DigestUtils.md5Hex(HOME_PAGE_NAME));
+        helloPluginSummaryPage.put("id", DigestUtils.md5Hex("Hello Plugin - Summary"));
+        helloPluginSummaryPage.put("space", "DOC");
+        titleToPage.put("Hello Plugin - Summary", helloPluginSummaryPage);
+
+        Map<String, String> helloPluginPluginsSummaryPage = new Hashtable<>();
+        helloPluginPluginsSummaryPage.put("title", "Hello Plugin - PluginsSummary");
+        helloPluginPluginsSummaryPage.put("parentId", DigestUtils.md5Hex(HOME_PAGE_NAME));
+        helloPluginPluginsSummaryPage.put("id", DigestUtils.md5Hex("Hello Plugin - PluginsSummary"));
+        helloPluginPluginsSummaryPage.put("space", "DOC");
+        titleToPage.put("Hello Plugin - PluginsSummary", helloPluginPluginsSummaryPage);
+
+        Map<String, String> helloPluginHelpPage = new Hashtable<>();
+        helloPluginHelpPage.put("title", "Hello Plugin - help");
+        helloPluginHelpPage.put("parentId", DigestUtils.md5Hex("Hello Plugin - Goals"));
+        helloPluginHelpPage.put("id", DigestUtils.md5Hex("Hello Plugin - help"));
+        helloPluginHelpPage.put("space", "DOC");
+        titleToPage.put("Hello Plugin - help", helloPluginHelpPage);
+
+        Map<String, String> helloPluginTouchPage = new Hashtable<>();
+        helloPluginTouchPage.put("title", "Hello Plugin - touch");
+        helloPluginTouchPage.put("parentId", DigestUtils.md5Hex("Hello Plugin - Goals"));
+        helloPluginTouchPage.put("id", DigestUtils.md5Hex("Hello Plugin - touch"));
+        helloPluginTouchPage.put("space", "DOC");
+        titleToPage.put("Hello Plugin - touch", helloPluginTouchPage);
 
         when(handler.getPage(anyString(), anyString(), anyString())).then( ( invocationOnMock ) -> {
 
@@ -108,13 +150,13 @@ public class TemplateVariablesInPagesTest {
                 if (titleToPage.containsKey(title)) {
                     return titleToPage.get(title);
                 }
-                return Collections.emptyMap();
+                return new Hashtable<>();
         });
-        
-        
-        
+
+
+
         when(handler.storePage(anyString(), any(Hashtable.class))).then( ( invocationOnMock ) -> {
-                Map<String, String> hashtable = new HashMap<>();
+                Map<String, String> hashtable = new Hashtable<>();
                 Map<String, String> pageMap = (Map<String, String>)invocationOnMock.getArguments()[1];
                 hashtable.putAll(pageMap);
                 Page page = new Page(pageMap);
@@ -122,7 +164,7 @@ public class TemplateVariablesInPagesTest {
                 String parentId = page.getParentId();
                 if (parentId != null) {
                     String parentTitle = null;
-                    
+
                     for (Map<String,String> map : titleToPage.values()) {
                         Page p = new Page(map);
                         if (parentId.equals(p.getId())) {
@@ -134,7 +176,7 @@ public class TemplateVariablesInPagesTest {
                         throw new IllegalStateException(format("pageId '%s' not found", parentId));
                     }
 
-                    fileWrite(results + "/" + parentTitle + "=>" + page.getTitle(), page.getContent());
+                    fileWrite(results + "/" + parentTitle + "==" + page.getTitle(), page.getContent());
                 } else {
                     fileWrite(results + "/" + page.getTitle(), page.getContent());
                 }
@@ -144,14 +186,14 @@ public class TemplateVariablesInPagesTest {
                 titleToPage.put(page.getTitle(), hashtable);
                 return hashtable;
             });
-      
+
 
         when(handler.getChildren(anyString(), anyString())).then(( invocationOnMock ) -> {
 
         		String parentPageId = (String)invocationOnMock.getArguments()[1];
-        		
+
                 List<Map<String,String>> children = new ArrayList<>();
-                
+
                 for (Map<String,String> pageMap : titleToPage.values()) {
                     Page page = new Page(pageMap);
                     if (parentPageId.equals(page.getParentId())) {
@@ -179,14 +221,14 @@ public class TemplateVariablesInPagesTest {
     public void shouldRenderTheIndexPage() throws IOException, VerificationException, InterruptedException {
         File testDir = simpleExtractResources(getClass(), "/simple-plugin-project");
         testLaunchingMaven(testDir, new ArrayList<>(), "clean", "package", "confluence-reporting:deploy");
-        assertTrue(fileExists(testDir.getAbsolutePath() + "/results/Fake Root=>Hello Plugin"));
-        assertTrue(fileExists(testDir.getAbsolutePath() + "/results/Hello Plugin=>Hello Plugin - Summary"));
+        assertTrue(fileExists(testDir.getAbsolutePath() + "/results/Fake Root==Hello Plugin"));
+        assertTrue(fileExists(testDir.getAbsolutePath() + "/results/Hello Plugin==Hello Plugin - Summary"));
 
-        String pluginGoalsPath = testDir.getAbsolutePath() + "/results/Hello Plugin=>Hello Plugin - Goals";
+        String pluginGoalsPath = testDir.getAbsolutePath() + "/results/Hello Plugin==Hello Plugin - Goals";
         assertTrue(fileExists(pluginGoalsPath));
         assertThat(fileRead(pluginGoalsPath), not(containsString("${plugin.goals}")));
 
-        String pluginsSummaryPath = testDir.getAbsolutePath() + "/results/Hello Plugin=>Hello Plugin - PluginsSummary";
+        String pluginsSummaryPath = testDir.getAbsolutePath() + "/results/Hello Plugin==Hello Plugin - PluginsSummary";
         assertTrue(fileExists(pluginsSummaryPath));
         String pluginsSummary = fileRead(pluginsSummaryPath);
         assertThat(pluginsSummary, not(containsString("${plugin.summary}")));
@@ -196,18 +238,18 @@ public class TemplateVariablesInPagesTest {
     public void shouldPutTheGoalsAsChildrenOfGoalsPage() throws IOException, VerificationException, InterruptedException {
         File testDir = simpleExtractResources(getClass(), "/plugin-project-goals-in-subpage");
         testLaunchingMaven(testDir, new ArrayList<>(), "clean", "package", "confluence-reporting:deploy");
-        assertTrue(fileExists(testDir.getAbsolutePath() + "/results/Fake Root=>Hello Plugin"));
-        String pluginGoalsPath = testDir.getAbsolutePath() + "/results/Hello Plugin=>Hello Plugin - Goals";
+        assertTrue(fileExists(testDir.getAbsolutePath() + "/results/Fake Root==Hello Plugin"));
+        String pluginGoalsPath = testDir.getAbsolutePath() + "/results/Hello Plugin==Hello Plugin - Goals";
         assertTrue(fileExists(pluginGoalsPath));
 
-        String pluginGoalhelpPath = testDir.getAbsolutePath() + "/results/Hello Plugin - Goals=>Hello Plugin - help";
+        String pluginGoalhelpPath = testDir.getAbsolutePath() + "/results/Hello Plugin - Goals==Hello Plugin - help";
         assertTrue("help goal should be a subpage of Goals", fileExists(pluginGoalhelpPath));
-        String pluginGoaltouchPath = testDir.getAbsolutePath() + "/results/Hello Plugin - Goals=>Hello Plugin - touch";
+        String pluginGoaltouchPath = testDir.getAbsolutePath() + "/results/Hello Plugin - Goals==Hello Plugin - touch";
         assertTrue("touch goal should be a subpage of Goals", fileExists(pluginGoaltouchPath));
 
         assertFalse("help goal should not be under the home page",
-                fileExists(testDir.getAbsolutePath() + "/results/Hello Plugin=>Hello Plugin - help"));
+                fileExists(testDir.getAbsolutePath() + "/results/Hello Plugin==Hello Plugin - help"));
         assertFalse("touch goal should not be under the home page",
-                fileExists(testDir.getAbsolutePath() + "/results/Hello Plugin=>Hello Plugin - touch"));
+                fileExists(testDir.getAbsolutePath() + "/results/Hello Plugin==Hello Plugin - touch"));
     }
 }


### PR DESCRIPTION
Hi @bsorrentino,

I tried fixing some problems in junit integration tests in `TemplateVariablesInPagesTest`:

- Switched from `Collections#emptyList` to `#ArrayList`, because the former is immutable, so adding new elements to `cliOptions` failed
- Switched from `HashMap` to `Hashtable`, because that's what [XML-RPC supports](https://developer.atlassian.com/server/confluence/rpc-module/) as `Map` implementation (this one actually took a long time to debug because ~~of swallowed exceptions and lack of clear documentation~~ i'm bad)
- Replaced the `>` in `=>` in filenames with another `=`, beacuse that's [illegal in non-Unix filenames](https://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words)
- Added mock response for children pages too