### PR TITLE
convert seconds to milliseconds when configure XmlRpcClientConfigImpl

### DIFF
--- a/core/src/main/java/org/bsc/confluence/ConfluenceService.java
+++ b/core/src/main/java/org/bsc/confluence/ConfluenceService.java
@@ -186,15 +186,15 @@ public interface ConfluenceService extends Closeable{
 
     static long getConnectTimeout(TimeUnit timeUnit) {
         final long seconds = Long.valueOf(System.getProperty( connectTimeoutInSeconds, "10"));
-        return  TimeUnit.SECONDS.convert(seconds, timeUnit);
+        return  timeUnit.convert(seconds, TimeUnit.SECONDS);
     }
     static long getWriteTimeout(TimeUnit timeUnit) {
         final long seconds = Long.valueOf(System.getProperty( writeTimeoutInSeconds, "10"));
-        return  TimeUnit.SECONDS.convert(seconds, timeUnit);
+        return  timeUnit.convert(seconds, TimeUnit.SECONDS);
     }
     static long getReadTimeout(TimeUnit timeUnit) {
         final long seconds = Long.valueOf(System.getProperty( readTimeoutInSeconds, "10"));
-        return  TimeUnit.SECONDS.convert(seconds, timeUnit);
+        return  timeUnit.convert(seconds, TimeUnit.SECONDS);
     }
 
     static void setConnectTimeouts( long value, TimeUnit timeUnit) {


### PR DESCRIPTION
HI @bsorrentino 

I believe #256 should be fixed in this way, because parameters

"confluence.timeout.connect.secs" and "confluence.timeout.write.secs" and  "confluence.timeout.read.secs"
defined in seconds

